### PR TITLE
Adds option for ordering default imports

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -8,6 +8,7 @@ import { Transform, Order, getTransform, orders } from "./order";
 export const schema: JSONSchema4 = {
   "source-order": { enum: orders },
   "specifier-order": { enum: orders },
+  "name-order": { enum: orders },
   "group-order": {
     type: "array",
     items: {
@@ -26,6 +27,7 @@ export const schema: JSONSchema4 = {
 export interface InputOptions {
   "source-order"?: Order;
   "specifier-order"?: Order;
+  "name-order"?: Order;
   "group-order"?: { name: string; match: string; order: number }[];
 }
 
@@ -40,11 +42,13 @@ export interface ImportGroupDefinition {
 export class Options {
   sourceOrder: Transform;
   specifierOrder: Transform;
+  nameOrder: Transform;
   groupOrder?: ImportGroupDefinition[];
 
   constructor(input: InputOptions) {
     this.specifierOrder = getTransform(input["specifier-order"] ?? "lowercase-last");
     this.sourceOrder = getTransform(input["source-order"] ?? "lowercase-last");
+    this.nameOrder = getTransform(input["name-order"] ?? "any");
 
     this.groupOrder = input["group-order"]?.map(g => ({
       name: g.name,

--- a/src/rule.spec.ts
+++ b/src/rule.spec.ts
@@ -38,6 +38,16 @@ import B from "B";
 import A from "A";
       `,
     },
+
+    // "name-order": "any"
+    {
+      options: [{ "name-order": "any" }],
+      code: `
+import b from 'a';
+import a from 'b';
+import c from 'c';
+      `,
+    },
   ],
   invalid: [
     // "specifier-order": "lowercase-last"
@@ -124,6 +134,51 @@ import C from "C";
         { message: "unordered import source" },
         { message: "unordered import source" },
       ],
+    },
+
+    // "name-order": "case-insensitive"
+    {
+      options: [{ "source-order": "any", "name-order": "case-insensitive" }],
+      code: `
+import C from "C";
+import { x } from "x";
+import a from "a";
+import b from "b";
+      `,
+      output: `
+import a from "a";
+import { x } from "x";
+import b from "b";
+import C from "C";
+      `,
+      errors: [
+        { message: "unordered import name" },
+        { message: "unordered import name" },
+        { message: "unordered import name" },
+      ]
+    },
+
+    // "name-order": "lowercase-last"
+    {
+      options: [{ "source-order": "any", "name-order": "lowercase-last" }],
+      code: `
+import C from "C";
+import b from "b";
+import { x } from "x";
+import a from "a";
+import D from "D";
+      `,
+      output: `
+import C from "C";
+import D from "D";
+import { x } from "x";
+import a from "a";
+import b from "b";
+      `,
+      errors: [
+        { message: "unordered import name" },
+        { message: "unordered import name" },
+      ]
     },
 
     // "groups" (order)


### PR DESCRIPTION
Great plugin! It almost satisfies our preferences, except that it lacks ordering of default imports.

This PR adds that, with the `name-order` option. I'm not sure that `name-order` is the best name (it could be `defaults-order` or `identifier-order` or something).

I'm also not sure about how to handle a list of mixed named/default imports. For now named imports are left alone if `source-order` is set to `any`.

The default for `name-order` is `any` (to avoid breaking changes), but `name-order` now takes precedence over `source-order`. Not sure how you feel about that.

I hope you'll take a look and consider adding this :) 