### PR TITLE
Fixes crash due to missing 'input.json'

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "author": "Kyle Mayes <kyle@mayeses.com> (https://kylemayes.com)",
   "repository": "github:KyleMayes/eslint-plugin-ordered-imports",
   "main": "dist/index.js",
+  "files": [
+    "dist",
+    "src",
+    "input.json"
+  ],
   "scripts": {
     "format": "prettier --write src/*.ts",
     "clean": "rimraf dist",


### PR DESCRIPTION
Fixes #2 

It seems like `input.json` needs to be explicitly whitelisted since it's excluded with `.gitignore`.

Package contents before this PR:
```
npm notice 📦  eslint-plugin-ordered-imports@0.2.0
npm notice === Tarball Contents ===
npm notice 12B    .gitattributes
npm notice 50B    .prettierrc
npm notice 200B   dist/index.js
npm notice 2.4kB  dist/options.js
npm notice 1.5kB  dist/ordering.js
npm notice 9.4kB  dist/rule.js
npm notice 16.3kB dist/rule.spec.js
npm notice 1.1kB  package.json
npm notice 120B   tsconfig.json
npm notice 210B   README.md
npm notice 122B   src/index.ts
npm notice 3.7kB  src/options.ts
npm notice 2.9kB  src/ordering.ts
npm notice 14.0kB src/rule.spec.ts
npm notice 7.7kB  src/rule.ts
npm notice 11.4kB LICENSE.txt
npm notice 803B   .github/workflows/ci.yaml
```

Package contents after this PR:

```
npm notice 📦  eslint-plugin-ordered-imports@0.2.0
npm notice === Tarball Contents ===
npm notice 200B   dist/index.js
npm notice 2.4kB  dist/options.js
npm notice 1.5kB  dist/ordering.js
npm notice 9.4kB  dist/rule.js
npm notice 16.3kB dist/rule.spec.js
npm notice 6.3kB  input.json
npm notice 1.2kB  package.json
npm notice 210B   README.md
npm notice 122B   src/index.ts
npm notice 3.7kB  src/options.ts
npm notice 2.9kB  src/ordering.ts
npm notice 14.0kB src/rule.spec.ts
npm notice 7.7kB  src/rule.ts
npm notice 11.4kB LICENSE.txt
```